### PR TITLE
[TASK] Improved the Sign-up Logic with Roles Validations

### DIFF
--- a/src/user/auth/auth.controller.ts
+++ b/src/user/auth/auth.controller.ts
@@ -1,18 +1,48 @@
-import { Body, Controller, Post } from '@nestjs/common';
-import { SigninDto, SignupDto } from '../dtos/auth.dto';
+import {
+  Body,
+  Controller,
+  Param,
+  ParseEnumPipe,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { GenerateProductKeyDto, SigninDto, SignupDto } from '../dtos/auth.dto';
 import { AuthService } from './auth.service';
+import { UserType } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  @Post('/signup')
-  signup(@Body() body: SignupDto) {
-    return this.authService.signup(body);
+  @Post('/signup/:userType')
+  async signup(
+    @Body() body: SignupDto,
+    @Param('userType', new ParseEnumPipe(UserType)) userType: UserType,
+  ) {
+    if (userType !== UserType.BUYER) {
+      if (!body.productKey) {
+        throw new UnauthorizedException();
+      }
+      const validProductKey = `${body.email}-${userType}-${process.env.PRODUCT_KEY_SECRET}`;
+      const isValidProductKey = await bcrypt.compare(
+        validProductKey,
+        body.productKey,
+      );
+      if (!isValidProductKey) {
+        throw new UnauthorizedException();
+      }
+    }
+    return this.authService.signup(body, userType);
   }
 
   @Post('/signin')
   signin(@Body() body: SigninDto) {
     return this.authService.signin(body);
+  }
+
+  @Post('/key')
+  generateProductKey(@Body() { email, userType }: GenerateProductKeyDto) {
+    return this.authService.generateProductKey(email, userType);
   }
 }

--- a/src/user/auth/auth.service.ts
+++ b/src/user/auth/auth.service.ts
@@ -21,7 +21,10 @@ export class AuthService {
   constructor(private readonly prisma: PrismaService) {}
 
   //*Sign-up validation
-  async signup({ email, password, name, phone }: SignupParams) {
+  async signup(
+    { email, password, name, phone }: SignupParams,
+    userType: UserType,
+  ) {
     //*Email validation
     const userExists = await this.prisma.user.findUnique({
       where: { email },
@@ -41,7 +44,7 @@ export class AuthService {
         name,
         phone,
         password: hashedPassword,
-        user_type: UserType.BUYER,
+        user_type: userType,
       },
     });
 
@@ -77,5 +80,11 @@ export class AuthService {
       process.env.JSON_TOKEN_KEY,
       { expiresIn: 3600000 },
     );
+  }
+
+  generateProductKey(email: string, userType: UserType) {
+    const string = `${email}-${userType}-${process.env.PRODUCT_KEY_SECRET}`;
+
+    return bcrypt.hash(string, 10);
   }
 }

--- a/src/user/dtos/auth.dto.ts
+++ b/src/user/dtos/auth.dto.ts
@@ -1,6 +1,9 @@
+import { UserType } from '@prisma/client';
 import {
   IsEmail,
+  IsEnum,
   IsNotEmpty,
+  IsOptional,
   IsString,
   Matches,
   MinLength,
@@ -22,6 +25,11 @@ export class SignupDto {
   @IsString()
   @MinLength(5)
   password: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  productKey?: string;
 }
 
 export class SigninDto {
@@ -30,4 +38,12 @@ export class SigninDto {
 
   @IsString()
   password: string;
+}
+
+export class GenerateProductKeyDto {
+  @IsEmail()
+  email: string;
+
+  @IsEnum(UserType)
+  userType: UserType;
 }


### PR DESCRIPTION
## Commands
- npx prisma studio

## Preconditions
- user/developer must access this link in Postman: localhost:3000/auth/signin/{REALTOR/USER/ADMIN}

## Expected Output
- {/auth/signup/key} will generate a key when a user signup with the desired role in the endpoint, and this only accessible to ADMINS
- An error will show if the user doesn't have a product key
- it will return an error when a registered user sign-up as a different role

## Screenshots
1. An endpoint that generates product key
![Screenshot 2023-10-11 163942](https://github.com/FrancisTuls/realtor-app-nestjs/assets/91929009/a29490f8-9a3b-4660-afa2-f03fa76992f7)

2. An error will show if the user doesn't have a product key
![Screenshot 2023-10-11 170910](https://github.com/FrancisTuls/realtor-app-nestjs/assets/91929009/34f1506e-f5fc-443c-8a7f-709b8d1d8e1e)

3. The token is returned when the user have complete requirements to become a REALTOR
![Screenshot 2023-10-11 171131](https://github.com/FrancisTuls/realtor-app-nestjs/assets/91929009/4861c0a8-02ae-4356-84e0-e9a848640709)

4. The error will appear when a REALTOR sign up as an ADMIN
![Screenshot 2023-10-11 170947](https://github.com/FrancisTuls/realtor-app-nestjs/assets/91929009/b74172e4-1bf5-4d88-a7ae-cebab7ed2d26)
